### PR TITLE
fix: 新增高度

### DIFF
--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -165,7 +165,7 @@ export function Xyzen({ backendUrl = DEFAULT_BACKEND_URL }: XyzenProps) {
           </button>
         </div>
 
-        <Tab.Group selectedIndex={activeTabIndex} onChange={setTabIndex}>
+        <Tab.Group selectedIndex={activeTabIndex} onChange={setTabIndex} style={{ height: '100vh' }}>
           <div className="border-b border-neutral-200 px-4 dark:border-neutral-800">
             <div className="flex items-center justify-between">
               <Tab.List className="flex space-x-1">

--- a/web/src/components/layouts/XyzenChat.tsx
+++ b/web/src/components/layouts/XyzenChat.tsx
@@ -100,7 +100,7 @@ export default function XyzenChat() {
   }
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full flex-col" style={{height: `calc(100vh - 136px)`}}>
       {currentAssistant ? (
         <div className="flex-shrink-0 px-4 pb-2">
           <h2 className="text-lg font-medium text-neutral-800 dark:text-white">


### PR DESCRIPTION
## 变更内容

- [x] 新功能
- [x] 修复 Bug
- [ ] 增强重构
- [ ] 其他（请描述）

简要描述本次 PR 的主要变更内容。

## 相关 Issue

请关联相关 Issue（如有）：#编号

## 检查清单

默认已勾选，如不满足，请检查。

- [x] 已在本地测试通过
- [x] 已补充/更新相关文档
- [x] 已添加测试用例
- [x] 代码风格已经过 pre-commit 钩子检查


## 其他说明

如有特殊说明或注意事项，请补充。

## Sourcery 总结

确保主应用标签页区域和聊天容器始终填充整个视口高度

增强功能:
- 在 `App.tsx` 中，将 `100vh` 高度样式应用于 `Tab.Group` 容器
- 在 `XyzenChat.tsx` 中，将聊天布局高度设置为 `calc(100vh - 136px)`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the main app tab area and chat container consistently fill the full viewport height

Enhancements:
- Apply 100vh height style to the Tab.Group container in App.tsx
- Set chat layout height to calc(100vh - 136px) in XyzenChat.tsx

</details>